### PR TITLE
fix: suppresses new dotenv messages

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import togglClient from 'toggl-client'
 import { readConfig } from './config.js'
-dotenv.config()
+dotenv.config({quiet:true})
 import debugClient from 'debug'
 const debug = debugClient('toggl-cli-client')
 


### PR DESCRIPTION
The new default behavior of dotenv is to provide some marketing for other packages
and to let the user know that it didn't load anything from .env. So, if you're not using
.env, the CLI output is unnecessarily verbose.
