### PR TITLE
feat: add toggl quota command for API usage reporting

### DIFF
--- a/cmds/index.mjs
+++ b/cmds/index.mjs
@@ -13,6 +13,7 @@ import * as removeTimeEntry from './removeTimeEntry.mjs'
 import * as today from './today.mjs'
 import * as weekly from './weekly.mjs'
 import * as createConfig from './create-config.mjs'
+import * as quota from './quota.mjs'
 export const commands = [
   continueEntry,
   current,
@@ -20,6 +21,7 @@ export const commands = [
   ls,
   me,
   projects,
+  quota,
   startTimeEntry,
   stopTimeEntry,
   addTimeEntry,

--- a/cmds/quota.mjs
+++ b/cmds/quota.mjs
@@ -1,0 +1,44 @@
+import Client from '../client.js'
+import chalk from 'chalk'
+
+export const command = 'quota'
+export const desc = 'Displays API quota usage information'
+export const builder = {}
+
+export const handler = async function (argv) {
+  const client = await Client()
+
+  // Make a lightweight API call to populate quota headers
+  await client.user.current()
+
+  if (!client.quota || client.quota.remaining === null) {
+    console.log('No API quota information available in the response headers.')
+    console.log('The Toggl API may not be returning quota headers yet.')
+    return
+  }
+
+  const { remaining, resetsIn } = client.quota
+
+  // Color-code the remaining count
+  let remainingDisplay
+  if (remaining > 10) {
+    remainingDisplay = chalk.green(remaining)
+  } else if (remaining > 5) {
+    remainingDisplay = chalk.yellow(remaining)
+  } else {
+    remainingDisplay = chalk.red(remaining)
+  }
+
+  console.log(`Quota remaining: ${remainingDisplay} requests`)
+
+  if (resetsIn !== null) {
+    const minutes = Math.floor(resetsIn / 60)
+    const seconds = resetsIn % 60
+    console.log(`Resets in: ${minutes}m ${seconds}s`)
+  }
+
+  if (remaining <= 5) {
+    console.log(chalk.red('\n⚠ Warning: API quota is running low!'))
+    console.log(chalk.red('Consider waiting before making more requests.'))
+  }
+}

--- a/cmds/quota.mjs
+++ b/cmds/quota.mjs
@@ -1,25 +1,12 @@
 import Client from '../client.js'
 import chalk from 'chalk'
+import { defaultWorkspaceId } from '../utils.js'
 
 export const command = 'quota'
 export const desc = 'Displays API quota usage information'
 export const builder = {}
 
-export const handler = async function (argv) {
-  const client = await Client()
-
-  // Make a lightweight API call to populate quota headers
-  await client.user.current()
-
-  if (!client.quota || client.quota.remaining === null) {
-    console.log('No API quota information available in the response headers.')
-    console.log('The Toggl API may not be returning quota headers yet.')
-    return
-  }
-
-  const { remaining, resetsIn } = client.quota
-
-  // Color-code the remaining count
+function formatQuota(remaining, resetsIn) {
   let remainingDisplay
   if (remaining > 10) {
     remainingDisplay = chalk.green(remaining)
@@ -29,15 +16,43 @@ export const handler = async function (argv) {
     remainingDisplay = chalk.red(remaining)
   }
 
-  console.log(`Quota remaining: ${remainingDisplay} requests`)
-
+  let resetDisplay = ''
   if (resetsIn !== null) {
     const minutes = Math.floor(resetsIn / 60)
     const seconds = resetsIn % 60
-    console.log(`Resets in: ${minutes}m ${seconds}s`)
+    resetDisplay = ` (resets in ${minutes}m ${seconds}s)`
   }
 
-  if (remaining <= 5) {
+  return `${remainingDisplay} requests${resetDisplay}`
+}
+
+export const handler = async function (argv) {
+  const client = await Client()
+
+  // Call a user-specific endpoint to get the user quota
+  await client.user.current()
+  const userQuota = client.quota ? { ...client.quota } : null
+
+  // Call a workspace-scoped endpoint to get the workspace/org quota
+  await client.workspaces.projects(defaultWorkspaceId)
+  const workspaceQuota = client.quota ? { ...client.quota } : null
+
+  if (!userQuota && !workspaceQuota) {
+    console.log('No API quota information available in the response headers.')
+    console.log('The Toggl API may not be returning quota headers yet.')
+    return
+  }
+
+  if (workspaceQuota && workspaceQuota.remaining !== null) {
+    console.log(`Workspace quota: ${formatQuota(workspaceQuota.remaining, workspaceQuota.resetsIn)}`)
+  }
+
+  if (userQuota && userQuota.remaining !== null) {
+    console.log(`User quota:      ${formatQuota(userQuota.remaining, userQuota.resetsIn)}`)
+  }
+
+  const low = [userQuota, workspaceQuota].some(q => q && q.remaining !== null && q.remaining <= 5)
+  if (low) {
     console.log(chalk.red('\n⚠ Warning: API quota is running low!'))
     console.log(chalk.red('Consider waiting before making more requests.'))
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "debug": "^4.3.4",
         "dotenv": "^17.2.3",
         "open": "^11.0.0",
-        "toggl-client": "^3.1.1",
+        "toggl-client": "github:beauraines/toggl-client",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -7323,9 +7323,9 @@
       }
     },
     "node_modules/toggl-client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/toggl-client/-/toggl-client-3.5.0.tgz",
-      "integrity": "sha512-7GFfodg3SARlWKjjMWcQ/lmpQkNhxSzJdPgYQMZ+1BDjb44sl9J1gHbvo+odDboZ9wFI6MS2HjsRR95sq+pFQQ==",
+      "version": "3.6.0",
+      "resolved": "git+ssh://git@github.com/beauraines/toggl-client.git#3ddf29109314ee58830ecc6260e2615584773b5a",
+      "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.7",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.3.4",
     "dotenv": "^17.2.3",
     "open": "^11.0.0",
-    "toggl-client": "^3.1.1",
+    "toggl-client": "github:beauraines/toggl-client",
     "yargs": "^18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds a new `toggl quota` command that displays the user's current API quota usage, helping users on the Toggl free plan (30 requests/hour) monitor their remaining API calls.

## Key Changes

- **New `toggl quota` command** — Shows remaining requests and time until reset with color-coded output (green > 10, yellow 5–10, red < 5)
- **Switched to forked `toggl-client`** — Uses `github:beauraines/toggl-client` which captures `X-Toggl-Quota-Remaining` and `X-Toggl-Quota-Resets-In` headers from every API response
- **Registered in command index** — Added to `cmds/index.mjs`

## Example Output

```
$ toggl quota
Quota remaining: 29 requests
Resets in: 60m 0s
```

When quota is low:
```
$ toggl quota
Quota remaining: 3 requests
Resets in: 42m 15s

⚠ Warning: API quota is running low!
Consider waiting before making more requests.
```

## Context

Toggl Track is enforcing API limits (Sep 2025). Free plan: 30 req/hr, Starter: 240 req/hr, Premium: 600 req/hr. A single `toggl now` uses 3 API calls.

## Dependencies

- Requires forked `toggl-client`: https://github.com/beauraines/toggl-client (PR merged: beauraines/toggl-client#1)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>