### PR TITLE
fix: improve error output when offline (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [2.8.3](https://github.com/beauraines/toggl-cli/compare/v2.8.2...v2.8.3) (2026-04-29)
-
-
-### Bug Fixes
-
-* improve error output when offline — show friendly message instead of raw stack trace ([#243](https://github.com/beauraines/toggl-cli/issues/243))
-
 ## [2.8.0](https://github.com/beauraines/toggl-cli/compare/v2.7.0...v2.8.0) (2026-02-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.8.3](https://github.com/beauraines/toggl-cli/compare/v2.8.2...v2.8.3) (2026-04-29)
+
+
+### Bug Fixes
+
+* improve error output when offline — show friendly message instead of raw stack trace ([#243](https://github.com/beauraines/toggl-cli/issues/243))
+
 ## [2.8.0](https://github.com/beauraines/toggl-cli/compare/v2.7.0...v2.8.0) (2026-02-28)
 
 

--- a/client.js
+++ b/client.js
@@ -8,6 +8,39 @@ const debug = debugClient('toggl-cli-client')
 
 const QUOTA_WARNING_THRESHOLD = 5
 
+const NETWORK_ERROR_CODES = new Set([
+  'ENOTFOUND',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'ECONNRESET',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+])
+
+const NETWORK_ERROR_MESSAGES = {
+  ENOTFOUND: 'Unable to resolve host — are you connected to the internet?',
+  ECONNREFUSED: 'Connection refused by the server.',
+  ETIMEDOUT: 'Connection timed out — the server may be unreachable.',
+  ENETUNREACH: 'Network is unreachable — check your internet connection.',
+  ECONNRESET: 'Connection was reset — please try again.',
+  EAI_AGAIN: 'DNS lookup failed — check your internet connection and try again.',
+  EHOSTUNREACH: 'Host is unreachable — check your internet connection.',
+}
+
+/**
+ * Strips sensitive credentials (API tokens, passwords) from a string
+ * to prevent accidental leakage in error output.
+ */
+export function sanitizeErrorMessage (message) {
+  if (!message) return message
+  // Strip Basic auth header values
+  message = message.replace(/Basic\s+[A-Za-z0-9+/=]+/g, 'Basic [REDACTED]')
+  // Strip API tokens in URLs (username:password@host pattern)
+  message = message.replace(/\/\/[^@/]+@/g, '//[REDACTED]@')
+  return message
+}
+
 export default async function () {
   let  conf
   try {
@@ -29,10 +62,26 @@ export default async function () {
      process.exit(1)
    }
 
-  // Wrap request method to warn when API quota is running low
+  // Wrap request method to handle errors and warn on quota
   const originalRequest = client.request.bind(client)
   client.request = async function (...args) {
-    const result = await originalRequest(...args)
+    let result
+    try {
+      result = await originalRequest(...args)
+    } catch (error) {
+      if (NETWORK_ERROR_CODES.has(error.code)) {
+        const friendlyMessage = NETWORK_ERROR_MESSAGES[error.code] || 'A network error occurred.'
+        console.error(chalk.red(`\n✖ ${friendlyMessage}`))
+        debug('Full error details: %O', error)
+        process.exit(1)
+      }
+      // For non-network errors, sanitize and re-throw
+      if (error.message) {
+        error.message = sanitizeErrorMessage(error.message)
+      }
+      throw error
+    }
+
     if (client.quota && client.quota.remaining !== null && client.quota.remaining <= QUOTA_WARNING_THRESHOLD) {
       const minutes = client.quota.resetsIn ? Math.ceil(client.quota.resetsIn / 60) : '?'
       console.error(chalk.yellow(`\n⚠ API quota low: ${client.quota.remaining} requests remaining (resets in ~${minutes}m)`))

--- a/client.test.js
+++ b/client.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from '@jest/globals'
+import { sanitizeErrorMessage } from './client.js'
+
+describe('sanitizeErrorMessage', () => {
+  it('should strip Basic auth header values', () => {
+    const input = 'Request failed: Basic YTQyOTk3YzEyZjExMTI4OTM0NGNlZDdlYWVkMmM6YXBpX3Rva2Vu'
+    const result = sanitizeErrorMessage(input)
+    expect(result).toBe('Request failed: Basic [REDACTED]')
+    expect(result).not.toContain('YTQyOTk3')
+  })
+
+  it('should strip credentials from URLs', () => {
+    const input = 'getaddrinfo ENOTFOUND at https://a42997c12f112821289344ced7eaed2c:api_token@api.track.toggl.com/api/v9/me'
+    const result = sanitizeErrorMessage(input)
+    expect(result).toContain('[REDACTED]@api.track.toggl.com')
+    expect(result).not.toContain('a42997c12f112821289344ced7eaed2c')
+  })
+
+  it('should handle null/undefined input', () => {
+    expect(sanitizeErrorMessage(null)).toBeNull()
+    expect(sanitizeErrorMessage(undefined)).toBeUndefined()
+    expect(sanitizeErrorMessage('')).toBe('')
+  })
+
+  it('should not modify messages without credentials', () => {
+    const input = 'Connection timed out'
+    expect(sanitizeErrorMessage(input)).toBe('Connection timed out')
+  })
+})

--- a/cmds/index.mjs
+++ b/cmds/index.mjs
@@ -14,7 +14,9 @@ import * as today from './today.mjs'
 import * as weekly from './weekly.mjs'
 import * as createConfig from './create-config.mjs'
 import * as quota from './quota.mjs'
-export const commands = [
+import { withErrorHandling } from '../errorHandler.js'
+
+const rawCommands = [
   continueEntry,
   current,
   edit,
@@ -32,3 +34,8 @@ export const commands = [
   workspace,
   createConfig
 ]
+
+export const commands = rawCommands.map(cmd => ({
+  ...cmd,
+  handler: withErrorHandling(cmd.handler)
+}))

--- a/errorHandler.js
+++ b/errorHandler.js
@@ -1,0 +1,26 @@
+import chalk from 'chalk'
+import debugClient from 'debug'
+import { sanitizeErrorMessage } from './client.js'
+
+const debug = debugClient('toggl-cli-error')
+
+/**
+ * Wraps a yargs command handler with error handling that catches
+ * unhandled errors and displays a user-friendly message instead
+ * of a raw stack trace with sensitive data.
+ *
+ * @param {Function} handler - The async handler function to wrap
+ * @returns {Function} - The wrapped handler
+ */
+export function withErrorHandling (handler) {
+  return async function (argv) {
+    try {
+      await handler(argv)
+    } catch (error) {
+      const message = sanitizeErrorMessage(error.message) || 'An unexpected error occurred.'
+      console.error(chalk.red(`\n✖ ${message}`))
+      debug('Full error details: %O', error)
+      process.exit(1)
+    }
+  }
+}

--- a/errorHandler.test.js
+++ b/errorHandler.test.js
@@ -1,0 +1,57 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { withErrorHandling } from './errorHandler.js'
+
+describe('withErrorHandling', () => {
+  let mockExit
+  let mockConsoleError
+
+  beforeEach(() => {
+    mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {})
+    mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    mockExit.mockRestore()
+    mockConsoleError.mockRestore()
+  })
+
+  it('should call the original handler when no error occurs', async () => {
+    const handler = jest.fn()
+    const wrapped = withErrorHandling(handler)
+    await wrapped({ test: true })
+    expect(handler).toHaveBeenCalledWith({ test: true })
+    expect(mockExit).not.toHaveBeenCalled()
+  })
+
+  it('should catch errors and display a friendly message', async () => {
+    const handler = jest.fn().mockRejectedValue(new Error('Something went wrong'))
+    const wrapped = withErrorHandling(handler)
+    await wrapped({})
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Something went wrong')
+    )
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it('should sanitize API tokens from error messages', async () => {
+    const error = new Error(
+      'Request failed: Basic YTQyOTk3YzEyZjExMTI4OTM0NGNlZDdlYWVkMmM6YXBpX3Rva2Vu'
+    )
+    const handler = jest.fn().mockRejectedValue(error)
+    const wrapped = withErrorHandling(handler)
+    await wrapped({})
+
+    const errorOutput = mockConsoleError.mock.calls[0][0]
+    expect(errorOutput).not.toContain('YTQyOTk3')
+    expect(errorOutput).toContain('[REDACTED]')
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it('should handle errors with no message', async () => {
+    const handler = jest.fn().mockRejectedValue(new Error())
+    const wrapped = withErrorHandling(handler)
+    await wrapped({})
+    expect(mockConsoleError).toHaveBeenCalled()
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "toggl": "./cli.js"
   },
   "scripts": {
-    "test": "jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "lint": "eslint . ./**/*.js ./**/*.mjs",
     "lint:fix": "eslint . ./**/*.js ./**/*.mjs --fix",
     "release": "standard-version",


### PR DESCRIPTION
## Summary

Fixes #243 — when the CLI is used offline, it now shows a friendly error message instead of dumping a raw stack trace with exposed API credentials.

### Before
```
RequestError: getaddrinfo ENOTFOUND api.track.toggl.com
    at ClientRequest.<anonymous> ...
  options: { headers: { authorization: 'Basic YTQyOTk3...' }, url: URL { ... } }
```

### After
```
✖ Unable to resolve host — are you connected to the internet?
```

### Key Changes

- **`client.js`** — Centralized network error handling in the `client.request` wrapper catches `ENOTFOUND`, `ECONNREFUSED`, `ETIMEDOUT`, `ENETUNREACH`, `ECONNRESET`, `EAI_AGAIN`, `EHOSTUNREACH` and shows a friendly chalk-colored message
- **`client.js`** — `sanitizeErrorMessage()` strips API tokens from Basic auth headers and URL credentials to prevent credential leakage
- **`errorHandler.js`** — `withErrorHandling()` wrapper catches any remaining unhandled errors in command handlers
- **`cmds/index.mjs`** — All command handlers are wrapped with `withErrorHandling()` centrally
- **Tests** — 8 new tests for sanitization and error handling
- Full error details remain available via `DEBUG=*` for troubleshooting

### No Breaking Changes
